### PR TITLE
Fix website scraper workflow failure

### DIFF
--- a/WebsiteScraper.java
+++ b/WebsiteScraper.java
@@ -182,10 +182,16 @@ public class WebsiteScraper {
                 progress.currentPage++;
                 log(String.format("Processing page %d/%d: %s", progress.currentPage, progress.totalPages, currentUrl));
                 sleep(REQUEST_DELAY_MS); // Rate limiting
-                Document doc = Jsoup.connect(currentUrl)
+                Document doc;
+                try {
+                    doc = Jsoup.connect(currentUrl)
                                   .userAgent("Mozilla/5.0")
                                   .timeout(CONNECTION_TIMEOUT_MS)
                                   .get();
+                } catch (IOException e) {
+                    log("Warning: Failed to fetch page " + currentUrl + ": " + e.getMessage());
+                    continue;
+                }
                 progress.processedUrls.add(currentUrl);
 
                 // Save progress periodically


### PR DESCRIPTION
## Summary
- handle network fetch errors when downloading a page

## Testing
- `javac WebsiteScraper.java` *(fails: package org.jsoup does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68520e445b38832386a20b9f743f73c4